### PR TITLE
Add support for `const`

### DIFF
--- a/docs/examples/OA-3.1.html
+++ b/docs/examples/OA-3.1.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+  <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src='https://www.googletagmanager.com/gtag/js?id=UA-132775238-1'></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-132775238-1');
+    </script>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes'>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600&family=Roboto+Mono&display=swap" rel="stylesheet">
+    <script type='text/javascript' src='../rapidoc-min.js'></script>
+
+    <link href='../index.css' rel='stylesheet'>
+  </head>
+  <body>
+    <rapi-doc id = "thedoc"
+      spec-url="../specs/oa-3.1.json"
+      allow-authentication = "false" 
+      show-info = "false"
+      show-header = "false"
+      render-style = "read"
+      allow-try = "true" 
+      regular-font = 'Open Sans'
+      mono-font = "Roboto Mono"
+    > 
+    <div slot="nav-logo">
+      <div slot="nav-logo" style="width:100%; display: flex; flex-direction:column;">
+        <div style="text-align: center; padding: 20px 0 12px 0; color:#47AFE8"> Allow TRY</div>
+        <div style="display: flex;justify-content: center; margin: 2px 0">
+          <button class='btn medium' onclick="document.getElementById('thedoc').setAttribute('allow-try', 'true')" >Yes</button>
+          <button class='btn medium' onclick="document.getElementById('thedoc').setAttribute('allow-try', 'false')" >No</button>
+        </div>
+
+        <div style="text-align: center; padding: 20px 0 12px 0; color:#47AFE8"> Schema Style</div>
+        <div style="display: flex;justify-content: center; margin: 2px 0">
+          <button class='btn medium' onclick="document.getElementById('thedoc').setAttribute('schema-style', 'table')" >Table</button>
+          <button class='btn medium' onclick="document.getElementById('thedoc').setAttribute('schema-style', 'tree')" >Tree</button>
+        </div>
+      </div>
+    </div>
+  </rapi-doc>
+  </body>
+</html>

--- a/docs/specs/oa-3.1.json
+++ b/docs/specs/oa-3.1.json
@@ -1,0 +1,47 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "components": {
+        "schemas": {
+            "options": {
+                "type": "object",
+                "properties": {
+                    "const": { "type": "string", "const": "a_fixed_value" },
+                    "enum": { "type": "string", "enum": ["a_single_enum_value"] },
+                    "const_array": { "type": "array", "items": { "type": "string", "enum": ["a_single_fixed_value"] } },
+                    "enum_array": { "type": "array", "items": { "type": "string", "const": "a_fixed_value" } }
+                }
+            }
+        }
+    },
+    "paths": {
+        "/consts": {
+            "post": {
+                "summary": "",
+                "description": "",
+                "operationId": "consts",
+                "requestBody": {
+                    "description": "The custom fields collection",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/options" }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "response",
+                        "content": {
+                            "application/json": {
+                                "schema": { "$ref": "#/components/schemas/options" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -312,7 +312,7 @@ export default class SchemaTable extends LitElement {
           ${dataType === 'array' ? html`<span class="m-markdown-small">${unsafeHTML(marked(description))}</span>` : ''}
           ${constraint ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>Constraints: </span> ${constraint}</div>` : ''}
           ${defaultValue ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>Default: </span>${defaultValue}</div>` : ''}
-          ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>Allowed: </span>${allowedValues}</div>` : ''}
+          ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>${type === 'const' ? 'Value' : 'Allowed'}: </span>${allowedValues}</div>` : ''}
           ${pattern ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>Pattern: </span>${pattern}</div>` : ''}
         </div>
       </div>

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -326,7 +326,7 @@ export default class SchemaTree extends LitElement {
           ${dataType === 'array' ? html`<span class="m-markdown-small">${unsafeHTML(marked(description))}</span>` : ''}
           ${constraint ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Constraints: </span>${constraint}</div>` : ''}
           ${defaultValue ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Default: </span>${defaultValue}</div>` : ''}
-          ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Allowed: </span>${allowedValues}</div>` : ''}
+          ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>${type === 'const' ? 'Value' : 'Allowed'}: </span>${allowedValues}</div>` : ''}
           ${pattern ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Pattern: </span>${pattern}</div>` : ''}
         </div>
       </div>

--- a/src/styles/schema-styles.js
+++ b/src/styles/schema-styles.js
@@ -72,6 +72,7 @@ export default css`
 .null {color:var(--red);}
 .bool, .boolean{color:var(--orange)}
 .enum {color:var(--purple)}
+.cons {color:var(--purple)}
 .recu {color:var(--brown)}
 .toolbar {
   display:flex;


### PR DESCRIPTION
This is allowed in OA 3.1 (See https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.1.3), but is not rendered properly (as a regular string for example, without the allowed values, or rather fixed value.

This PR adds support for that.

Examples: at https://sneakyvv.github.io/RapiDoc/examples/OA-3.1.html

![image](https://user-images.githubusercontent.com/1423157/188662258-7f7ecc19-0c5c-47ff-aac2-f19508245139.png)

![image](https://user-images.githubusercontent.com/1423157/188662223-9df28d18-9294-4e0c-a732-67a38d142132.png)

For schema at https://sneakyvv.github.io/RapiDoc/specs/oa-3.1.json



Note: it doesn't check whether the openapi version in the schema is >= 3.1.0