### PR TITLE
Fix description of array item properties

### DIFF
--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -309,7 +309,7 @@ export default class SchemaTable extends LitElement {
         </div>
         ${dataTypeHtml}
         <div class='td key-descr' @click="${() => { this.schemaDescriptionExpanded = 'true'; }}">
-          ${dataType === 'array' ? html`<span class="m-markdown-small">${unsafeHTML(marked(description))}</span>` : ''}
+          ${html`<span class="m-markdown-small">${unsafeHTML(marked(dataType === 'array' ? description : schemaDescription))}</span>`}
           ${constraint ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>Constraints: </span> ${constraint}</div>` : ''}
           ${defaultValue ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>Default: </span>${defaultValue}</div>` : ''}
           ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px;'> <span class='bold-text'>${type === 'const' ? 'Value' : 'Allowed'}: </span>${allowedValues}</div>` : ''}

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -323,7 +323,7 @@ export default class SchemaTree extends LitElement {
           </span>
         </div>
         <div class='td key-descr'>
-          ${dataType === 'array' ? html`<span class="m-markdown-small">${unsafeHTML(marked(description))}</span>` : ''}
+          ${html`<span class="m-markdown-small">${unsafeHTML(marked(dataType === 'array' ? description : schemaDescription))}</span>`}
           ${constraint ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Constraints: </span>${constraint}</div>` : ''}
           ${defaultValue ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Default: </span>${defaultValue}</div>` : ''}
           ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>${type === 'const' ? 'Value' : 'Allowed'}: </span>${allowedValues}</div>` : ''}


### PR DESCRIPTION
### Problem

The `schemaDescription` was completely dropped in https://github.com/rapi-doc/RapiDoc/commit/f1c79ad57b5cda96c3bce2b6e246eab7ec4312f6#diff-aff82d0bded49c3f8384e0f3eae76b28d01e50dbe421ce2616dab8d9392e1d72L315-L324 after being refactored/improved in a couple of commits (https://github.com/rapi-doc/RapiDoc/commit/33893203d2869e3b0dff079232749ec01b682d99, https://github.com/rapi-doc/RapiDoc/commit/154cb679cbb5197e5428cce689174b8649f35c06, https://github.com/rapi-doc/RapiDoc/commit/154cb679cbb5197e5428cce689174b8649f35c06, https://github.com/rapi-doc/RapiDoc/commit/dd3ae6dfb24cddecbd078525c8a42557fa5516de, https://github.com/rapi-doc/RapiDoc/commit/24388e402fb3bb50e9a17eef28daa5ee9375ab7a).

No idea why it was completely dropped, but this breaks the rendering of the description for item properties of an array. Might have been because the new description features like multi-line etc didn't need to be on nested array item properties, but it was removed to eagerly. 

For example:
![image](https://user-images.githubusercontent.com/1423157/189640339-a441162b-6976-4245-a1f7-53b61b0ef597.png)
The id property above has a description, which is not rendered.

### Solution

If I remember correctly the `description` variable was for when rendering a scalar property, but only for an array. The `schemaDescription` variable was for other scalar properties (aka object properties) which needed some other / more elaborate rendering. 

Since the part for rendering the `schemaDescription` has been removed, but too eagerly, I just used that variable in the first array-rendering section, instead of re-adding the schema-description-rendering section that had been removed in the commits mentioned above.