### PR TITLE
Correct HTTP basic auth header value

### DIFF
--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -16,8 +16,7 @@ export function applyApiKey(securitySchemeId, username = '', password = '', prov
   let finalApiKeyValue = '';
   if (securityObj.scheme?.toLowerCase() === 'basic') {
     if (username) {
-      finalApiKeyValue = Buffer.from(`${username}:${password}`, 'utf8').toString('base64');
-      // finalApiKeyValue = `Basic ${btoa(`${username}:${password}`)}`;
+      finalApiKeyValue = `Basic ${Buffer.from(`${username}:${password}`, 'utf8').toString('base64')}`;
     }
   } else if (providedApikeyVal) {
     securityObj.value = providedApikeyVal;


### PR DESCRIPTION
- fixes #875 

Looks like regression accidentally introduced with https://github.com/rapi-doc/RapiDoc/commit/26f1db71bae22820b7027c0f3c3411f6adc96921