### PR TITLE
Add ability to limit token endpoint auth method options (x-receive-token-in)

### DIFF
--- a/docs/specs/oauth-vendor-extension.yaml
+++ b/docs/specs/oauth-vendor-extension.yaml
@@ -15,10 +15,11 @@ info:
         securitySchemes:
           exampleOauth2Flow:
             type: oauth2
-            x-client-id: my-client-id             # <--- when provided it will be pre filled in RapiDoc UI
-            x-client-secret: my-client-secret     # <--- when provided it will be pre filled in RapiDoc UI
-            x-default-scopes: [dog-lover]         # <--- when provided scopes will be pre checked in RapiDoc UI
-            x-receive-token-in: request-body      # <--- can be 'header' or 'request-body' when provided this will be pre selected
+            x-client-id: my-client-id                              # <--- when provided it will be pre filled in RapiDoc UI
+            x-client-secret: my-client-secret                      # <--- when provided it will be pre filled in RapiDoc UI
+            x-default-scopes: [dog-lover]                          # <--- when provided scopes will be pre checked in RapiDoc UI
+            x-receive-token-in: request-body                       # <--- can be 'header' or 'request-body' when provided this will be pre selected
+            x-receive-token-in-options: ["header", "request-body"] # <--- when provided it will limit options available 
             flows:
               authorizationCode:
                 authorizationUrl: /authorize

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -256,7 +256,7 @@ async function onInvokeOAuthFlow(securitySchemeId, flowType, authUrl, tokenUrl, 
 
 /* eslint-disable indent */
 
-function oAuthFlowTemplate(flowName, clientId, clientSecret, securitySchemeId, authFlow, defaultScopes = [], receiveTokenIn = 'header') {
+function oAuthFlowTemplate(flowName, clientId, clientSecret, securitySchemeId, authFlow, defaultScopes = [], receiveTokenIn = 'header', receiveTokenInOptions = undefined) {
   let { authorizationUrl, tokenUrl, refreshUrl } = authFlow;
   const pkceOnly = authFlow['x-pkce-only'] || false;
   const isUrlAbsolute = (url) => (url.indexOf('://') > 0 || url.indexOf('//') === 0);
@@ -350,8 +350,8 @@ function oAuthFlowTemplate(flowName, clientId, clientSecret, securitySchemeId, a
                   style = "margin:0 5px;${pkceOnly ? 'display:none;' : ''}"
                 >
                 <select style="margin-right:5px;${pkceOnly ? 'display:none;' : ''}" class="${flowName} ${securitySchemeId} oauth-send-client-secret-in">
-                  <option value = 'header' .selected = ${receiveTokenIn === 'header'} > Authorization Header </option>
-                  <option value = 'request-body' .selected = ${receiveTokenIn === 'request-body'}> Request Body </option>
+                   ${(!receiveTokenInOptions || receiveTokenInOptions.includes('header')) ? html`<option value = 'header' .selected = ${receiveTokenIn === 'header'} > Authorization Header </option>` : ''}
+                   ${(!receiveTokenInOptions || receiveTokenInOptions.includes('request-body')) ? html` <option value = 'request-body' .selected = ${receiveTokenIn === 'request-body'}> Request Body </option>` : ''}
                 </select>`
               : ''
             }
@@ -483,6 +483,7 @@ export default function securitySchemeTemplate() {
                         v.flows[f],
                         (v.flows[f]['x-default-scopes'] || v['x-default-scopes']),
                         (v.flows[f]['x-receive-token-in'] || v['x-receive-token-in']),
+                        (v.flows[f]['x-receive-token-in-options'] || v['x-receive-token-in-options']),
                       ))}
                   </td>
                 </tr>


### PR DESCRIPTION
Add ability to limit token endpoint auth method options (x-receive-token-in) in dropdown (see screenshot)

![image](https://user-images.githubusercontent.com/65282808/227237193-53203705-624b-48a1-8067-048f13fd2ac2.png)
