### PR TITLE
Distinguish nullable arrays when schema-style is tree

### DIFF
--- a/docs/specs/temp.yaml
+++ b/docs/specs/temp.yaml
@@ -28,10 +28,10 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: 
+              additionalProperties:
                 type: integer
               patternProperties:
-                S_: 
+                S_:
                   type: integer
               properties:
                 foo:
@@ -173,13 +173,28 @@ components:
           type: string
           nullable: true
           description: Generated URL
-        tags:
+        ages:
+          type: array
+          nullable: true
+          items:
+            allOf:
+              - type: string
+            nullable: true
+        tags_array:
           type: array
           items:
             allOf:
               - $ref: '#/components/schemas/tag'
             nullable: true
-        cat:
+        tags_array_array:
+          type: array
+          items:
+            nullable: true
+            type: array
+            items:
+              allOf:
+                - $ref: '#/components/schemas/tag'
+        cat_object:
           allOf:
             - $ref: '#/components/schemas/category'
           nullable: true

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -179,9 +179,9 @@ export default class SchemaTree extends LitElement {
     if (data['::type'] === 'object') {
       if (dataType === 'array') {
         if (schemaLevel < this.schemaExpandLevel) {
-          openBracket = html`<span class="open-bracket array-of-object" >[{</span>`;
+          openBracket = html`<span class="open-bracket array-of-object" >${data['::nullable'] ? 'null┃' : ''}[{</span>`;
         } else {
-          openBracket = html`<span class="open-bracket array-of-object">[{...}]</span>`;
+          openBracket = html`<span class="open-bracket array-of-object">${data['::nullable'] ? 'null┃' : ''}[{...}]</span>`;
         }
         closeBracket = '}]';
       } else {
@@ -196,16 +196,16 @@ export default class SchemaTree extends LitElement {
       if (dataType === 'array') {
         const arrType = arrayType !== 'object' ? arrayType : '';
         if (schemaLevel < this.schemaExpandLevel) {
-          openBracket = html`<span class="open-bracket array-of-array" data-array-type="${arrType}">[[ ${arrType} </span>`;
+          openBracket = html`<span class="open-bracket array-of-array" data-array-type="${arrType}">${data['::nullable'] ? 'null┃' : ''}[[ ${arrType} </span>`;
         } else {
-          openBracket = html`<span class="open-bracket array-of-array"  data-array-type="${arrType}">[[...]]</span>`;
+          openBracket = html`<span class="open-bracket array-of-array"  data-array-type="${arrType}">${data['::nullable'] ? 'null┃' : ''}[[...]]</span>`;
         }
         closeBracket = ']]';
       } else {
         if (schemaLevel < this.schemaExpandLevel) {
-          openBracket = html`<span class="open-bracket array">[</span>`;
+          openBracket = html`<span class="open-bracket array">${data['::nullable'] ? 'null┃' : ''}[</span>`;
         } else {
-          openBracket = html`<span class="open-bracket array">[...]</span>`;
+          openBracket = html`<span class="open-bracket array">${data['::nullable'] ? 'null┃' : ''}[...]</span>`;
         }
         closeBracket = ']';
       }
@@ -352,25 +352,31 @@ export default class SchemaTree extends LitElement {
   toggleObjectExpand(e) {
     const rowEl = e.target.closest('.tr');
     const nullable = rowEl.classList.contains('nullable');
+    let objectRepr = '';
     if (rowEl.classList.contains('expanded')) {
       rowEl.classList.replace('expanded', 'collapsed');
-      e.target.innerHTML = e.target.classList.contains('array-of-object')
+      objectRepr = e.target.classList.contains('array-of-object')
         ? '[{...}]'
         : e.target.classList.contains('array-of-array')
           ? '[[...]]'
           : e.target.classList.contains('array')
             ? '[...]'
-            : `${nullable ? 'null┃' : ''}{...}`;
+            : '{...}';
     } else {
       rowEl.classList.replace('collapsed', 'expanded');
-      e.target.innerHTML = e.target.classList.contains('array-of-object')
+      objectRepr = e.target.classList.contains('array-of-object')
         ? '[{'
         : e.target.classList.contains('array-of-array')
           ? `[[ ${e.target.dataset.arrayType}`
           : e.target.classList.contains('object')
-            ? `${nullable ? 'null┃' : ''}{`
+            ? '{'
             : '[';
     }
+    if (nullable) {
+      objectRepr = `null┃${objectRepr}`;
+    }
+
+    e.target.innerHTML = objectRepr;
   }
 }
 customElements.define('schema-tree', SchemaTree);


### PR DESCRIPTION
Follow-up to https://github.com/rapi-doc/RapiDoc/pull/889

Also display `null|..` for nullable arrays (of arrays / objects)

Can't display `null|...` for primitives, as that is handled very differently and `nullable` is not available when rendering them

Previously: 

![image](https://user-images.githubusercontent.com/5418540/232733879-1b8c40d4-9b99-49ae-bdf8-02c678240453.png)

Current:

![image](https://user-images.githubusercontent.com/5418540/232733635-6895768d-9035-45bd-a921-80244b3427dc.png)