### PR TITLE
New possibility to add enums with labels through oneof

### DIFF
--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -212,7 +212,7 @@ export default class SchemaTable extends LitElement {
       return html`
         ${newSchemaLevel >= 0 && key
           ? html`
-            <div class='tr ${newSchemaLevel <= this.schemaExpandLevel ? 'expanded' : 'collapsed'} ${data['::type']}' data-obj='${keyLabel}' title="${data['::deprecated'] ? 'Deprecated' : ''}">
+            <div class='tr ${isOneOfEnum || newSchemaLevel <= this.schemaExpandLevel ? 'expanded' : 'collapsed'} ${data['::type']}' data-obj='${keyLabel}' title="${data['::deprecated'] ? 'Deprecated' : ''}">
               <div class="td key ${data['::deprecated'] ? 'deprecated' : ''}" style='padding-left:${leftPadding}px'>
                 ${!isOneOfEnum && (keyLabel || keyDescr)
                   ? html`

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -725,7 +725,7 @@ export function schemaInObjectNotation(schema, obj, level = 0, suffix = '') {
     let objKey = schema.anyOf ? `::ANY~OF ${suffix}` : `::ONE~OF ${suffix}`;
 
     if (xxxOfEnum) {
-      obj['::type'] = 'enum';
+      obj['::type'] = 'object';
       obj['::dataTypeLabel'] = 'enum';
       objKey = `::ONE~OF~ENUM ${suffix}`;
     } else {


### PR DESCRIPTION
As discussed in [**this Stackoverflow thread**](https://stackoverflow.com/questions/66465888/how-to-define-enum-mapping-in-openapi) there is no way to create enums with labels out of the box (like enums of integers for some configurations). The simplest workaround is to use a `oneOf` with constant values.

As show below, displayed with rapidoc this leads in a very confusing documentation :

<details>
<summary>Openapi schema sample</summary>
<pre>
{
        "format": "int32",
        "oneOf": [
          {
            "const": 0,
            "format": "int32",
            "title": "LAST_UPDATED_SOURCE_NOT_SET",
            "type": "const"
          },
          {
            "const": 1,
            "format": "int32",
            "title": "BIKE_GPS",
            "type": "const",
            "description": "some description"
          },
          {
            "const": 2,
            "format": "int32",
            "title": "APP_DATA",
            "type": "const",
            "description": "some other description"
          }]
}
</pre>
</details>

![Capture d’écran 2023-05-19 à 15 40 27](https://github.com/rapi-doc/RapiDoc/assets/20032117/93dfc69f-9afc-42c5-bf62-3f41f21a45c4)

Therefore I implemented a more suited way to display a one iff it contains only constant values :

![Capture d’écran 2023-05-19 à 15 40 02](https://github.com/rapi-doc/RapiDoc/assets/20032117/1fc99861-d726-4c7a-8dc0-28bb3fbb15ec)

Hope you find this convincing 😉