### PR TITLE
add ctrl+enter shortcut to fire a request

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -692,6 +692,12 @@ export default class ApiRequest extends LitElement {
                       const requestPanelEl = this.getRequestPanel(e);
                       this.liveCURLSyntaxUpdate(requestPanelEl);
                     }}
+                    @keydown=${(e) => {
+                      if ((e.keyCode === 10 || e.keyCode === 13) && e.ctrlKey) {
+                        return this.onTryClick(e);
+                      }
+                    }}
+
                   ></textarea>
                 </div>  
               `)}


### PR DESCRIPTION
Allows to press Ctrl + Enter in the textarea of the `ApiRequest` to send a request

The code `10` is here to support an open issue on Chromium : https://bugs.chromium.org/p/chromium/issues/detail?id=79407