### PR TITLE
Update curl examples to include --compressed flag

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1619,7 +1619,7 @@ export default class ApiRequest extends LitElement {
       curlUrl = fetchUrl;
     }
 
-    curl = `curl -X ${this.method.toUpperCase()} "${curlUrl}" \\\n`;
+    curl = `curl --compressed -X ${this.method.toUpperCase()} "${curlUrl}" \\\n`;
 
     curlHeaders = Array.from(fetchHeaders).map(([key, value]) => ` -H "${key}: ${value}"`).join('\\\n');
     if (curlHeaders) {


### PR DESCRIPTION
A very simplistic optimisation to include `--compressed` argument to generated curl examples. While this may be blocked on some  configurations, it should work for most. Especially when working with large results, this can heavily save data size being transferred over network.