### PR TITLE
Fixes #977: Adding attribute `sort-schemas`

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -131,6 +131,14 @@
             <td class='default-col'>false</td>
           </tr>
           <tr>
+            <td class="attr-col mono bold right">sort-schemas </td>
+            <td class="gray"><span class='bold dark-gray'>Allowed:<span class='blue'> true | false</span></span> To list schemas in alphabetic order,
+              otherwise schemas will be ordered based on how it is specified under the <span class = "mono blue bold">schemas</span> section in the spec.
+              Only has an effect if focused render-style and show-components are applied.
+            </td>
+            <td class='default-col'>false</td>
+          </tr>
+          <tr>
             <td class="attr-col mono bold right">sort-endpoints-by </td>
             <td class="gray"><span class='bold dark-gray'>
               Allowed:<span class='blue'> path | method | summary | none </span></span>

--- a/src/json-schema-viewer.js
+++ b/src/json-schema-viewer.js
@@ -287,6 +287,7 @@ export default class JsonSchemaViewer extends LitElement {
         specUrl,
         this.generateMissingTags === 'true',
         this.sortTags === 'true',
+        this.sortSchemas === 'true',
         this.getAttribute('sort-endpoints-by'),
       );
       this.loading = false;

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -55,6 +55,7 @@ export default class RapiDoc extends LitElement {
       routePrefix: { type: String, attribute: 'route-prefix' },
       specUrl: { type: String, attribute: 'spec-url' },
       sortTags: { type: String, attribute: 'sort-tags' },
+      sortSchemas: { type: String, attribute: 'sort-schemas' },
       generateMissingTags: { type: String, attribute: 'generate-missing-tags' },
       sortEndpointsBy: { type: String, attribute: 'sort-endpoints-by' },
       specFile: { type: String, attribute: false },
@@ -492,6 +493,7 @@ export default class RapiDoc extends LitElement {
     if (!this.updateRoute || !'true, false,'.includes(`${this.updateRoute},`)) { this.updateRoute = 'true'; }
     if (!this.routePrefix) { this.routePrefix = '#'; }
     if (!this.sortTags || !'true, false,'.includes(`${this.sortTags},`)) { this.sortTags = 'false'; }
+    if (!this.sortSchemas || !'true, false,'.includes(`${this.sortSchemas},`)) { this.sortSchemas = 'false'; }
     if (!this.generateMissingTags || !'true, false,'.includes(`${this.generateMissingTags},`)) { this.generateMissingTags = 'false'; }
     if (!this.sortEndpointsBy || !'method, path, summary, none,'.includes(`${this.sortEndpointsBy},`)) { this.sortEndpointsBy = 'path'; }
 
@@ -728,6 +730,7 @@ export default class RapiDoc extends LitElement {
         specUrl,
         this.generateMissingTags === 'true',
         this.sortTags === 'true',
+        this.sortSchemas === 'true',
         this.getAttribute('sort-endpoints-by'),
         this.getAttribute('api-key-name'),
         this.getAttribute('api-key-location'),

--- a/src/utils/spec-parser.js
+++ b/src/utils/spec-parser.js
@@ -3,7 +3,7 @@ import OpenApiParser from '@apitools/openapi-parser';
 import { marked } from 'marked';
 import { invalidCharsRegEx, rapidocApiKey, sleep } from '~/utils/common-utils';
 
-export default async function ProcessSpec(specUrl, generateMissingTags = false, sortTags = false, sortEndpointsBy = '', attrApiKey = '', attrApiKeyLocation = '', attrApiKeyValue = '', serverUrl = '') {
+export default async function ProcessSpec(specUrl, generateMissingTags = false, sortTags = false, sortSchemas = false, sortEndpointsBy = '', attrApiKey = '', attrApiKeyLocation = '', attrApiKeyValue = '', serverUrl = '') {
   let jsonParsedSpec;
   try {
     this.requestUpdate(); // important to show the initial loader
@@ -53,7 +53,7 @@ export default async function ProcessSpec(specUrl, generateMissingTags = false, 
   const tags = groupByTags(jsonParsedSpec, sortEndpointsBy, generateMissingTags, sortTags);
 
   // Components
-  const components = getComponents(jsonParsedSpec);
+  const components = getComponents(jsonParsedSpec, sortSchemas);
 
   // Info Description Headers
   const infoDescriptionHeaders = jsonParsedSpec.info?.description ? getHeadersFromMarkdown(jsonParsedSpec.info.description) : [];
@@ -162,7 +162,7 @@ function getHeadersFromMarkdown(markdownContent) {
   return headers || [];
 }
 
-function getComponents(openApiSpec) {
+function getComponents(openApiSpec, sortSchemas = false) {
   if (!openApiSpec.components) {
     return [];
   }
@@ -184,6 +184,10 @@ function getComponents(openApiSpec) {
 
     switch (component) {
       case 'schemas':
+        if (sortSchemas) {
+          subComponents.sort((c1, c2) => c1.name.localeCompare(c2.name));
+        }
+
         cmpName = 'Schemas';
         cmpDescription = 'Schemas allows the definition of input and output data types. These types can be objects, but also primitives and arrays.';
         break;


### PR DESCRIPTION
Hi,
This PR adds the functionality I asked for in #977. I locally tested it in the browser and building the project does not trigger any errors.

Even though the feature has not yet been accepted, I have implemented it. Maybe this will help me convince you to add this attribute to RapiDoc. ;-)

If you have any further questions, please feel free to ask.

Many thanks in advance!
Maschga