### PR TITLE
Always search the description of the path

### DIFF
--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -55,7 +55,7 @@ export function componentIsInSearch(searchVal, component) {
 
 export function pathIsInSearch(searchVal, path, matchType = 'includes') {
   if (matchType === 'includes') {
-    const stringToSearch = `${path.method} ${path.path} ${path.summary || path.description || ''} ${path.operationId || ''}`.toLowerCase();
+    const stringToSearch = `${path.method} ${path.path} ${path.summary || ''} ${path.description || ''} ${path.operationId || ''}`.toLowerCase();
     return stringToSearch.includes(searchVal.toLowerCase());
   }
   const regex = new RegExp(searchVal, 'i');


### PR DESCRIPTION
The patch improves the function 'pathIsInSearch' by ensuring that we always check the description when one is set. The current behavior avoids it when 'path.summary' is set.