### PR TITLE
Fix #966: Search click handler on spans

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1465,6 +1465,21 @@ export default class ApiRequest extends LitElement {
       const startTime = performance.now();
       fetchResponse = await fetch(fetchRequest, { signal });
       const endTime = performance.now();
+      // Allow to modify response
+      let resolveModifiedResponse; // Create a promise that will be resolved from the event listener
+      const modifiedResponsePromise = new Promise((resolve) => {
+        resolveModifiedResponse = resolve;
+      });
+      this.dispatchEvent(new CustomEvent('fetched-try', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          request: fetchRequest,
+          response: fetchResponse,
+          resolveModifiedResponse, // pass the resolver function
+        },
+      }));
+      fetchResponse = await modifiedResponsePromise; // Wait for the modified response
       responseClone = fetchResponse.clone(); // create a response clone to allow reading response body again (response.json, response.text etc)
       tryBtnEl.disabled = false;
       this.responseMessage = html`${fetchResponse.statusText ? `${fetchResponse.statusText}:${fetchResponse.status}` : fetchResponse.status} <div style="color:var(--light-fg)"> Took ${Math.round(endTime - startTime)} milliseconds </div>`;

--- a/src/templates/advance-search-template.js
+++ b/src/templates/advance-search-template.js
@@ -59,9 +59,9 @@ export default function searchByPropertiesModalTemplate() {
           }
         }"
       > 
-        <span data-content-id='${path.elementId}' class="upper bold-text method-fg ${path.method}">${path.method}</span> 
-        <span data-content-id='${path.elementId}'>${path.path}</span>
-        <span data-content-id='${path.elementId}' class="regular-font gray-text">${path.summary}</span>
+        <span style="pointer-events: none" class="upper bold-text method-fg ${path.method}">${path.method}</span> 
+        <span style="pointer-events: none">${path.path}</span>
+        <span style="pointer-events: none" class="regular-font gray-text">${path.summary}</span>
       </div>
     `)
     }


### PR DESCRIPTION
Fixes an issue (https://github.com/rapi-doc/RapiDoc/issues/966) with search where clicking on endpoint path/method is not scrolling due to event handler checking on event.target.contentId attribute. open to ideas/thoughts for a better fix

    if (!navEl.dataset.contentId) {
      return;
    }

This fix makes sure when clicking on any child element to scroll to that endpoint

element: https://github.com/rapi-doc/RapiDoc/blob/18afdce428b1bc6838d52c9f391a982817271da4/src/templates/advance-search-template.js#L48

**Event handler condition** 

https://github.com/rapi-doc/RapiDoc/blob/18afdce428b1bc6838d52c9f391a982817271da4/src/rapidoc.js#L952

**Video:**

https://github.com/rapi-doc/RapiDoc/assets/139879471/9e49658c-6632-4aa5-ace7-4cae272fcee6

