### PR TITLE
Curl header dedupe

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1623,7 +1623,7 @@ export default class ApiRequest extends LitElement {
 
     fetchHeaders.forEach((value, key) => {
       let tempHeaderArray = value.split(',');
-      tempHeaderArray = tempHeaderArray.map((el) => el.trim()).filter((value, index) => tempHeaderArray.indexOf(value) === index);
+      tempHeaderArray = tempHeaderArray.map((el) => el.trim()).filter((string, index) => tempHeaderArray.indexOf(string) === index);
       fetchHeaders.set(key, tempHeaderArray.join(', '));
     });
 

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1621,9 +1621,9 @@ export default class ApiRequest extends LitElement {
 
     curl = `curl -X ${this.method.toUpperCase()} "${curlUrl}" \\\n`;
 
-    fetchHeaders.forEach((value, key) =>{
-      let tempHeaderArray = value.split(",");
-      tempHeaderArray = tempHeaderArray.map(el => el.trim()).filter((value, index) => tempHeaderArray.indexOf(value) === index);
+    fetchHeaders.forEach((value, key) => {
+      let tempHeaderArray = value.split(',');
+      tempHeaderArray = tempHeaderArray.map((el) => el.trim()).filter((value, index) => tempHeaderArray.indexOf(value) === index);
       fetchHeaders.set(key, tempHeaderArray.join(', '));
     });
 

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1621,6 +1621,12 @@ export default class ApiRequest extends LitElement {
 
     curl = `curl -X ${this.method.toUpperCase()} "${curlUrl}" \\\n`;
 
+    fetchHeaders.forEach((value, key) =>{
+      let tempHeaderArray = value.split(",");
+      tempHeaderArray = tempHeaderArray.map(el => el.trim()).filter((value, index) => tempHeaderArray.indexOf(value) === index);
+      fetchHeaders.set(key, tempHeaderArray.join(', '));
+    });
+
     curlHeaders = Array.from(fetchHeaders).map(([key, value]) => ` -H "${key}: ${value}"`).join('\\\n');
     if (curlHeaders) {
       curlHeaders = `${curlHeaders} \\\n`;


### PR DESCRIPTION
This removes duplicate headers found in generated cURL examples. This address the issue https://github.com/rapi-doc/RapiDoc/issues/1023 . This really only effects the "accept" headers but is written in such a way that all duplicates are removed.

Before:
`curl -X GET "https://example.com" \
 -H "accept: application/json, application/json"\
 -H "accept-encoding: gzip"\
`

After:
`curl -X GET "https://example.com" \
 -H "accept: application/json"\
 -H "accept-encoding: gzip"\
`