### PR TITLE
fix: do not parse header content-type if empty

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1528,11 +1528,12 @@ export default class ApiRequest extends LitElement {
         respHeadersObj[hdr] = hdrVal;
         this.responseHeaders = `${this.responseHeaders}${hdr}: ${hdrVal}\n`;
       });
-      const contentType = fetchResponse.headers.get('content-type').split(';')[0].trim();
+      let contentType = fetchResponse.headers.get('content-type');
       const respEmpty = (await fetchResponse.clone().text()).length === 0;
       if (respEmpty) {
         this.responseText = '';
       } else if (contentType) {
+        contentType = contentType.split(';')[0].trim();
         if (contentType === 'application/x-ndjson') {
           this.responseText = await fetchResponse.text();
         } else if (contentType.includes('json')) {


### PR DESCRIPTION
This is a proposal fix for #1035. It avoids the error by parsing the `content-type` header only if its value is not `null`